### PR TITLE
Allow pagination on unions and subqueries

### DIFF
--- a/test/support/airplane.ex
+++ b/test/support/airplane.ex
@@ -1,0 +1,12 @@
+defmodule Paginator.Airplane do
+  use Ecto.Schema
+
+  schema "airplanes" do
+    field(:name, :string)
+    field(:year, :integer)
+    field(:type, :string)
+    field(:seats, :integer)
+
+    timestamps()
+  end
+end

--- a/test/support/boat.ex
+++ b/test/support/boat.ex
@@ -1,0 +1,12 @@
+defmodule Paginator.Boat do
+  use Ecto.Schema
+
+  schema "boats" do
+    field(:name, :string)
+    field(:year, :integer)
+    field(:type, :string)
+    field(:capacity, :integer)
+
+    timestamps()
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -10,7 +10,7 @@ defmodule Paginator.DataCase do
       import Paginator.Factory
 
       alias Paginator.{Page, Page.Metadata}
-      alias Paginator.{Customer, Address, Payment}
+      alias Paginator.{Customer, Address, Payment, Boat, Airplane}
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,7 +1,7 @@
 defmodule Paginator.Factory do
   use ExMachina.Ecto, repo: Paginator.Repo
 
-  alias Paginator.{Customer, Address, Payment}
+  alias Paginator.{Customer, Address, Payment, Boat, Airplane}
 
   def customer_factory do
     %Customer{
@@ -25,6 +25,24 @@ defmodule Paginator.Factory do
       amount: :rand.uniform(100) + 10,
       status: "success",
       customer: build(:customer)
+    }
+  end
+
+  def boat_factory do
+    %Boat{
+      name: "My Boat",
+      year: 2019,
+      type: "Sloop",
+      capacity: 1
+    }
+  end
+
+  def airplane_factory do
+    %Airplane{
+      name: "Spitfire",
+      year: 1936,
+      type: "Fighter",
+      seats: 1
     }
   end
 end

--- a/test/support/test_migration.ex
+++ b/test/support/test_migration.ex
@@ -25,5 +25,23 @@ defmodule Paginator.TestMigration do
 
       add(:customer_id, references(:customers))
     end
+
+    create table(:boats) do
+      add(:name, :string)
+      add(:year, :integer)
+      add(:type, :string)
+      add(:capacity, :integer)
+
+      timestamps()
+    end
+
+    create table(:airplanes) do
+      add(:name, :string)
+      add(:year, :integer)
+      add(:type, :string)
+      add(:seats, :integer)
+
+      timestamps()
+    end
   end
 end


### PR DESCRIPTION
Optimizes the count query builder.
Optimizes queries in combinations (e.g. inside unions and subqueries)
Fixes paginator, to allow it to paginate subqueries.