### PR TITLE
feat: add support for all asc/desc sorting order combinations

### DIFF
--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -25,7 +25,14 @@ defmodule Paginator.Config do
   @minimum_limit 1
   @maximum_limit 500
   @default_total_count_limit 10_000
-  @order_directions [:asc, :desc]
+  @order_directions [
+    :asc,
+    :asc_nulls_last,
+    :asc_nulls_first,
+    :desc,
+    :desc_nulls_first,
+    :desc_nulls_last
+  ]
 
   def new(opts \\ []) do
     %__MODULE__{

--- a/lib/paginator/ecto/query.ex
+++ b/lib/paginator/ecto/query.ex
@@ -40,8 +40,14 @@ defmodule Paginator.Ecto.Query do
     value = Map.get(values, column)
     {q_position, q_binding} = column_position(query, column)
 
-    dynamic_filter_builder = DynamicFilterBuilder.builder!(order, cursor_direction, value)
-    dynamic_filter_builder.(q_position, q_binding, true)
+    DynamicFilterBuilder.build!(%{
+      sort_order: order,
+      direction: cursor_direction,
+      value: value,
+      entity_position: q_position,
+      column: q_binding,
+      next_filters: true
+    })
   end
 
   defp build_where_expression(query, [{column, order} | fields], values, cursor_direction) do
@@ -50,8 +56,14 @@ defmodule Paginator.Ecto.Query do
 
     filters = build_where_expression(query, fields, values, cursor_direction)
 
-    dynamic_filter_builder = DynamicFilterBuilder.builder!(order, cursor_direction, value)
-    dynamic_filter_builder.(q_position, q_binding, filters)
+    DynamicFilterBuilder.build!(%{
+      sort_order: order,
+      direction: cursor_direction,
+      value: value,
+      entity_position: q_position,
+      column: q_binding,
+      next_filters: filters
+    })
   end
 
   defp maybe_where(query, %Config{

--- a/lib/paginator/ecto/query.ex
+++ b/lib/paginator/ecto/query.ex
@@ -4,6 +4,7 @@ defmodule Paginator.Ecto.Query do
   import Ecto.Query
 
   alias Paginator.Config
+  alias Paginator.Ecto.Query.DynamicFilterBuilder
 
   def paginate(queryable, config \\ [])
 
@@ -16,22 +17,6 @@ defmodule Paginator.Ecto.Query do
   def paginate(queryable, opts) do
     config = Config.new(opts)
     paginate(queryable, config)
-  end
-
-  defp get_operator(:desc, :before, nil), do: :isnull
-  defp get_operator(:desc, :before, _not_nil), do: :gt
-  defp get_operator(:desc, :after, nil), do: :isnull_or_notisnull
-  defp get_operator(:desc, :after, _not_nil), do: :lt
-  defp get_operator(:asc, :before, nil), do: :isnull_or_notisnull
-  defp get_operator(:asc, :before, _not_nil), do: :lt
-  defp get_operator(:asc, :after, nil), do: :isnull
-  defp get_operator(:asc, :after, _not_nil), do: :gt
-
-  defp get_operator(direction, _, _),
-    do: raise("Invalid sorting value :#{direction}, please use either :asc or :desc")
-
-  defp get_operator_for_field(order, direction, value) do
-    get_operator(order, direction, value)
   end
 
   # This clause is responsible for transforming legacy list cursors into map cursors
@@ -55,11 +40,8 @@ defmodule Paginator.Ecto.Query do
     value = Map.get(values, column)
     {q_position, q_binding} = column_position(query, column)
 
-    case get_operator_for_field(order, cursor_direction, value) do
-      :lt -> dynamic([{q, q_position}], field(q, ^q_binding) < ^value)
-      :gt when not is_nil(value) -> dynamic([{q, q_position}], field(q, ^q_binding) > ^value)
-      _ -> true
-    end
+    dynamic_filter_builder = DynamicFilterBuilder.builder!(order, cursor_direction, value)
+    dynamic_filter_builder.(q_position, q_binding, true)
   end
 
   defp build_where_expression(query, [{column, order} | fields], values, cursor_direction) do
@@ -68,32 +50,8 @@ defmodule Paginator.Ecto.Query do
 
     filters = build_where_expression(query, fields, values, cursor_direction)
 
-    case get_operator_for_field(order, cursor_direction, value) do
-      :lt ->
-        dynamic(
-          [{q, q_position}],
-          (field(q, ^q_binding) == ^value and ^filters) or
-            field(q, ^q_binding) < ^value
-        )
-
-      :gt ->
-        dynamic(
-          [{q, q_position}],
-          (field(q, ^q_binding) == ^value and ^filters) or
-            field(q, ^q_binding) > ^value or
-            is_nil(field(q, ^q_binding))
-        )
-
-      :isnull ->
-        dynamic([{q, q_position}], is_nil(field(q, ^q_binding)) and ^filters)
-
-      :isnull_or_notisnull ->
-        dynamic(
-          [{q, q_position}],
-          (is_nil(field(q, ^q_binding)) and ^filters) or
-            not is_nil(field(q, ^q_binding))
-        )
-    end
+    dynamic_filter_builder = DynamicFilterBuilder.builder!(order, cursor_direction, value)
+    dynamic_filter_builder.(q_position, q_binding, filters)
   end
 
   defp maybe_where(query, %Config{
@@ -169,8 +127,10 @@ defmodule Paginator.Ecto.Query do
                 Enum.map(expr, fn
                   {:desc, ast} -> {:asc, ast}
                   {:desc_nulls_first, ast} -> {:asc_nulls_last, ast}
+                  {:desc_nulls_last, ast} -> {:asc_nulls_first, ast}
                   {:asc, ast} -> {:desc, ast}
                   {:asc_nulls_last, ast} -> {:desc_nulls_first, ast}
+                  {:asc_nulls_first, ast} -> {:desc_nulls_last, ast}
                 end)
           }
         end

--- a/lib/paginator/ecto/query/asc_nulls_first.ex
+++ b/lib/paginator/ecto/query/asc_nulls_first.ex
@@ -4,65 +4,57 @@ defmodule Paginator.Ecto.Query.AscNullsFirst do
   import Ecto.Query
 
   @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, nil) do
-    fn
-      _, _, true ->
-        raise("unstable sort order: nullable columns can't be used as the last term")
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, value) do
-    fn
-      position, binding, true ->
-        dynamic(
-          [{query, position}],
-          field(query, ^binding) > ^value
-        )
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) > ^value
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, nil) do
-    fn
-      _, _, true ->
-        raise("unstable sort order: nullable columns can't be used as the last term")
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          is_nil(field(query, ^binding)) and ^filters
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, value) do
-    fn
-      position, binding, true ->
-        dynamic(
-          [{query, position}],
-          field(query, ^binding) < ^value or is_nil(field(query, ^binding))
-        )
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value
+    )
+  end
 
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value or
-            is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) < ^args.value or is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value or
+        is_nil(field(query, ^args.column))
+    )
   end
 end

--- a/lib/paginator/ecto/query/asc_nulls_first.ex
+++ b/lib/paginator/ecto/query/asc_nulls_first.ex
@@ -1,0 +1,68 @@
+defmodule Paginator.Ecto.Query.AscNullsFirst do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, nil) do
+    fn
+      _, _, true ->
+        raise("unstable sort order: nullable columns can't be used as the last term")
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, value) do
+    fn
+      position, binding, true ->
+        dynamic(
+          [{query, position}],
+          field(query, ^binding) > ^value
+        )
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) > ^value
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, nil) do
+    fn
+      _, _, true ->
+        raise("unstable sort order: nullable columns can't be used as the last term")
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          is_nil(field(query, ^binding)) and ^filters
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, value) do
+    fn
+      position, binding, true ->
+        dynamic(
+          [{query, position}],
+          field(query, ^binding) < ^value or is_nil(field(query, ^binding))
+        )
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value or
+            is_nil(field(query, ^binding))
+        )
+    end
+  end
+end

--- a/lib/paginator/ecto/query/asc_nulls_last.ex
+++ b/lib/paginator/ecto/query/asc_nulls_last.ex
@@ -4,60 +4,54 @@ defmodule Paginator.Ecto.Query.AscNullsLast do
   import Ecto.Query
 
   @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, nil) do
-    fn
-      _, _, true ->
-        raise("unstable sort order: nullable columns can't be used as the last term")
-
-      position, binding, filters ->
-        dynamic([{query, position}], is_nil(field(query, ^binding)) and ^filters)
-    end
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, value) do
-    fn
-      position, binding, true ->
-        dynamic(
-          [{query, position}],
-          field(query, ^binding) > ^value or is_nil(field(query, ^binding))
-        )
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or
-            field(query, ^binding) > ^value or
-            is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, nil) do
-    fn
-      _, _, true ->
-        raise("unstable sort order: nullable columns can't be used as the last term")
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value or is_nil(field(query, ^args.column))
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, value) do
-    fn
-      position, binding, true ->
-        dynamic([{query, position}], field(query, ^binding) < ^value)
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value or
+        is_nil(field(query, ^args.column))
+    )
+  end
 
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value
-        )
-    end
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic([{query, args.entity_position}], field(query, ^args.column) < ^args.value)
+  end
+
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value
+    )
   end
 end

--- a/lib/paginator/ecto/query/asc_nulls_last.ex
+++ b/lib/paginator/ecto/query/asc_nulls_last.ex
@@ -1,0 +1,63 @@
+defmodule Paginator.Ecto.Query.AscNullsLast do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, nil) do
+    fn
+      _, _, true ->
+        raise("unstable sort order: nullable columns can't be used as the last term")
+
+      position, binding, filters ->
+        dynamic([{query, position}], is_nil(field(query, ^binding)) and ^filters)
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, value) do
+    fn
+      position, binding, true ->
+        dynamic(
+          [{query, position}],
+          field(query, ^binding) > ^value or is_nil(field(query, ^binding))
+        )
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or
+            field(query, ^binding) > ^value or
+            is_nil(field(query, ^binding))
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, nil) do
+    fn
+      _, _, true ->
+        raise("unstable sort order: nullable columns can't be used as the last term")
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, value) do
+    fn
+      position, binding, true ->
+        dynamic([{query, position}], field(query, ^binding) < ^value)
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value
+        )
+    end
+  end
+end

--- a/lib/paginator/ecto/query/desc_nulls_first.ex
+++ b/lib/paginator/ecto/query/desc_nulls_first.ex
@@ -4,59 +4,54 @@ defmodule Paginator.Ecto.Query.DescNullsFirst do
   import Ecto.Query
 
   @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, nil) do
-    fn
-      _, _, true ->
-        raise("can't establish a stable ordering")
-
-      position, binding, filters ->
-        dynamic([{query, position}], is_nil(field(query, ^binding)) and ^filters)
-    end
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("can't establish a stable ordering")
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, value) do
-    fn
-      position, binding, true ->
-        dynamic(
-          [{query, position}],
-          field(query, ^binding) > ^value or is_nil(field(query, ^binding))
-        )
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) > ^value or
-            is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, nil) do
-    fn
-      _, _, true ->
-        raise("can't establish a stable ordering")
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value or is_nil(field(query, ^args.column))
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, value) do
-    fn
-      position, binding, true ->
-        dynamic([{query, position}], field(query, ^binding) < ^value)
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value or
+        is_nil(field(query, ^args.column))
+    )
+  end
 
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value
-        )
-    end
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic([{query, args.entity_position}], field(query, ^args.column) < ^args.value)
+  end
+
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value
+    )
   end
 end

--- a/lib/paginator/ecto/query/desc_nulls_first.ex
+++ b/lib/paginator/ecto/query/desc_nulls_first.ex
@@ -1,0 +1,62 @@
+defmodule Paginator.Ecto.Query.DescNullsFirst do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, nil) do
+    fn
+      _, _, true ->
+        raise("can't establish a stable ordering")
+
+      position, binding, filters ->
+        dynamic([{query, position}], is_nil(field(query, ^binding)) and ^filters)
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, value) do
+    fn
+      position, binding, true ->
+        dynamic(
+          [{query, position}],
+          field(query, ^binding) > ^value or is_nil(field(query, ^binding))
+        )
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) > ^value or
+            is_nil(field(query, ^binding))
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, nil) do
+    fn
+      _, _, true ->
+        raise("can't establish a stable ordering")
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, value) do
+    fn
+      position, binding, true ->
+        dynamic([{query, position}], field(query, ^binding) < ^value)
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value
+        )
+    end
+  end
+end

--- a/lib/paginator/ecto/query/desc_nulls_last.ex
+++ b/lib/paginator/ecto/query/desc_nulls_last.ex
@@ -1,0 +1,68 @@
+defmodule Paginator.Ecto.Query.DescNullsLast do
+  @behaviour Paginator.Ecto.Query.DynamicFilterBuilder
+
+  import Ecto.Query
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, nil) do
+    fn
+      _, _, true ->
+        raise("unstable sort order: nullable columns can't be used as the last term")
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:before, value) do
+    fn
+      position, binding, true ->
+        dynamic(
+          [{query, position}],
+          field(query, ^binding) > ^value
+        )
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) > ^value
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, nil) do
+    fn
+      _, _, true ->
+        raise("unstable sort order: nullable columns can't be used as the last term")
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          is_nil(field(query, ^binding)) and ^filters
+        )
+    end
+  end
+
+  @impl Paginator.Ecto.Query.DynamicFilterBuilder
+  def build_dynamic_filter(:after, value) do
+    fn
+      position, binding, true ->
+        dynamic(
+          [{query, position}],
+          field(query, ^binding) < ^value or is_nil(field(query, ^binding))
+        )
+
+      position, binding, filters ->
+        dynamic(
+          [{query, position}],
+          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value or
+            is_nil(field(query, ^binding))
+        )
+    end
+  end
+end

--- a/lib/paginator/ecto/query/desc_nulls_last.ex
+++ b/lib/paginator/ecto/query/desc_nulls_last.ex
@@ -4,65 +4,57 @@ defmodule Paginator.Ecto.Query.DescNullsLast do
   import Ecto.Query
 
   @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, nil) do
-    fn
-      _, _, true ->
-        raise("unstable sort order: nullable columns can't be used as the last term")
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (is_nil(field(query, ^binding)) and ^filters) or not is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(%{direction: :before, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:before, value) do
-    fn
-      position, binding, true ->
-        dynamic(
-          [{query, position}],
-          field(query, ^binding) > ^value
-        )
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) > ^value
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :before, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (is_nil(field(query, ^args.column)) and ^args.next_filters) or
+        not is_nil(field(query, ^args.column))
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, nil) do
-    fn
-      _, _, true ->
-        raise("unstable sort order: nullable columns can't be used as the last term")
-
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          is_nil(field(query, ^binding)) and ^filters
-        )
-    end
+  def build_dynamic_filter(args = %{direction: :before, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) > ^args.value
+    )
   end
 
-  @impl Paginator.Ecto.Query.DynamicFilterBuilder
-  def build_dynamic_filter(:after, value) do
-    fn
-      position, binding, true ->
-        dynamic(
-          [{query, position}],
-          field(query, ^binding) < ^value or is_nil(field(query, ^binding))
-        )
+  def build_dynamic_filter(args = %{direction: :before}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) > ^args.value
+    )
+  end
 
-      position, binding, filters ->
-        dynamic(
-          [{query, position}],
-          (field(query, ^binding) == ^value and ^filters) or field(query, ^binding) < ^value or
-            is_nil(field(query, ^binding))
-        )
-    end
+  def build_dynamic_filter(%{direction: :after, value: nil, next_filters: true}) do
+    raise("unstable sort order: nullable columns can't be used as the last term")
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, value: nil}) do
+    dynamic(
+      [{query, args.entity_position}],
+      is_nil(field(query, ^args.column)) and ^args.next_filters
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after, next_filters: true}) do
+    dynamic(
+      [{query, args.entity_position}],
+      field(query, ^args.column) < ^args.value or is_nil(field(query, ^args.column))
+    )
+  end
+
+  def build_dynamic_filter(args = %{direction: :after}) do
+    dynamic(
+      [{query, args.entity_position}],
+      (field(query, ^args.column) == ^args.value and ^args.next_filters) or
+        field(query, ^args.column) < ^args.value or
+        is_nil(field(query, ^args.column))
+    )
   end
 end

--- a/lib/paginator/ecto/query/dynamic_filter_builder.ex
+++ b/lib/paginator/ecto/query/dynamic_filter_builder.ex
@@ -1,0 +1,29 @@
+defmodule Paginator.Ecto.Query.DynamicFilterBuilder do
+  @type dynamic_filter_builder :: (integer(), term(), Ecto.Query.t() -> Ecto.Query.t())
+
+  @callback build_dynamic_filter(:after | :before, term()) :: dynamic_filter_builder()
+
+  @dispatch_table %{
+    desc: Paginator.Ecto.Query.DescNullsFirst,
+    desc_nulls_first: Paginator.Ecto.Query.DescNullsFirst,
+    desc_nulls_last: Paginator.Ecto.Query.DescNullsLast,
+    asc: Paginator.Ecto.Query.AscNullsLast,
+    asc_nulls_last: Paginator.Ecto.Query.AscNullsLast,
+    asc_nulls_first: Paginator.Ecto.Query.AscNullsFirst
+  }
+
+  @spec builder!(atom(), :after | :before, term()) :: dynamic_filter_builder()
+  def builder!(sort_order, direction, value) do
+    case Map.fetch(@dispatch_table, sort_order) do
+      {:ok, module} ->
+        apply(module, :build_dynamic_filter, [direction, value])
+
+      :error ->
+        available_sort_orders = Map.keys(@dispatch_table) |> Enum.join(", ")
+
+        raise(
+          "Invalid sorting value :#{sort_order}, please please use either #{available_sort_orders}"
+        )
+    end
+  end
+end


### PR DESCRIPTION
This patch adds support for all supported sorting orders when the
field is nullable. It is now possible to specify the following extra
sort orders in the cursor_fields:

  * asc_nulls_last, asc_nulls_first
  * desc_nulls_last, desc_nulls_first

As the number of different combinations is large, we refactored the
code that builds the dynamic filter expressions to make it a bit more
manageable. Each sorting order is now a separate module.

## Related issues

* CLC-2496